### PR TITLE
feat: auto light-dark mode (no scripts!)

### DIFF
--- a/pages/a_picture_is_worth_a_thousand_tags.html
+++ b/pages/a_picture_is_worth_a_thousand_tags.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>A picture is worth a thousand tags</title>
 	<meta name="description" content="This shows how a picture can be turned into an HTML table. With this, you can not only have nicer tables or uglier pictures, but you can have something that is both at the same time.">
 	<meta name="keywords" content="demos">

--- a/pages/a_smooth_and_sharp_image_interpolation.html
+++ b/pages/a_smooth_and_sharp_image_interpolation.html
@@ -1,8 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>A smooth and sharp image interpolation you probably haven't heard of</title>
 	<meta name="description" content="An image interpolation that gives us a continuous and smooth image, where every interpolated value only depends on the four neighboring pixel values. The image becomes smooth, but sharp features remain sharp.">
 	<meta name="keywords" content="mathematics, algorithms, demos">
@@ -192,7 +193,7 @@ function interpolate0(pixels, i0, j0, i1, j1) {
 	const w = canvas_i0.width;
 	const h = Math.floor(w * (i1 - i0) / (j1 - j0));
 	canvas_i0.height = h;
-	
+
 	pixels_i0 = white(w, h);
 	for(var i = 0; i < h; ++i) {
 		for(var j = 0; j < w; ++j) {
@@ -212,11 +213,11 @@ function interpolate1(pixels, i0, j0, i1, j1) {
 	const w = canvas_i1.width;
 	const h = Math.floor(w * (i1 - i0) / (j1 - j0));
 	canvas_i1.height = h;
-	
+
 	pixels_i1 = white(w, h);
-	
+
 	const n = 1.;
-	
+
 	for(var i = 0; i < h; ++i) {
 		for(var j = 0; j < w; ++j) {
 			const ix = j0 + (j1-j0)*j / w + 0.0001;
@@ -337,7 +338,7 @@ function draw_canvas(){
 		context.lineWidth = 3;
 		context.stroke();
 		context.closePath();
-		
+
 		context.beginPath();
 		context.lineDashOffset = 4;
 		context.moveTo(points[0][0] + 0.5, points[0][1] + 0.5);
@@ -349,7 +350,7 @@ function draw_canvas(){
 		context.setLineDash([4, 4]);
 		context.lineWidth = 3;
 		context.stroke();
-		context.closePath();		
+		context.closePath();
 		context.setLineDash([]);
 	}
 }
@@ -435,7 +436,7 @@ function load_pixels_from(url) {
 			});
 		});
 	});
-	
+
 }
 
 function load() {
@@ -675,7 +676,7 @@ And here are the square pixels.
 	</p>
 	<canvas id="canvas_i0" width=640 height=512></canvas>
 	<p>
-You can make the picture nice and smooth by employing an image interpolation. 
+You can make the picture nice and smooth by employing an image interpolation.
 	</p>
 	<p>
 Common interpolations for that are bilinear and bicubic. (see <a href="https://wordsandbuttons.online/biwhatever_transformations.html">Bi-whatever transformations</a>) The downside of the bilinear one is that it makes your image continuous, so no squares, but not smooth, so the upscale still looks unnatural. The downside of bicubic interpolation is that, while it does give you a nice and smooth picture, it smudges the thing a little so sharp features 1 pixel wide appear to be 3 pixels wide after the interpolation.
@@ -685,7 +686,7 @@ Here is another interpolation you probably haven't heard about before.
 	<p>
 	<canvas id="canvas_i1" width=640 height=512></canvas>
 	<p>
-This is an inverse weight interpolation, a close relative of a <a href="https://wordsandbuttons.online/swine_simplicial_weight_interpolation_and_extrapolation.html">SWInE</a>, not to be confused with "<a href="https://wordsandbuttons.online/programmers_guide_to_polynomials_and_splines.html">spline</a>". The whole inverse weight family is not highly popular partially due to its computational issues, and partially, because their localization for spatial applications is tricky. But here, for the image interpolation, the localization is not tricky at all. 
+This is an inverse weight interpolation, a close relative of a <a href="https://wordsandbuttons.online/swine_simplicial_weight_interpolation_and_extrapolation.html">SWInE</a>, not to be confused with "<a href="https://wordsandbuttons.online/programmers_guide_to_polynomials_and_splines.html">spline</a>". The whole inverse weight family is not highly popular partially due to its computational issues, and partially, because their localization for spatial applications is tricky. But here, for the image interpolation, the localization is not tricky at all.
 	</p>
 	<p>
 Let's start with a simple 1D case. We have a pair of values and we want to interpolate between them.

--- a/pages/all_algorithms.html
+++ b/pages/all_algorithms.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Words and buttons online</title>
 	<meta name="description" content="A collection of interactive pages about maths and programming" />
 	<meta http-equiv="Cache-Control" content="no-cache" />

--- a/pages/all_demos.html
+++ b/pages/all_demos.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Words and buttons online</title>
 	<meta name="description" content="A collection of interactive pages about maths and programming" />
 	<meta http-equiv="Cache-Control" content="no-cache" />

--- a/pages/all_mathematics.html
+++ b/pages/all_mathematics.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Words and buttons online</title>
 	<meta name="description" content="A collection of interactive pages about maths and programming" />
 	<meta http-equiv="Cache-Control" content="no-cache" />

--- a/pages/all_programming.html
+++ b/pages/all_programming.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Words and buttons online</title>
 	<meta name="description" content="A collection of interactive pages about maths and programming" />
 	<meta http-equiv="Cache-Control" content="no-cache" />

--- a/pages/all_quizzes.html
+++ b/pages/all_quizzes.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Words and buttons online</title>
 	<meta name="description" content="A collection of interactive pages about maths and programming" />
 	<meta http-equiv="Cache-Control" content="no-cache" />

--- a/pages/all_tutorials.html
+++ b/pages/all_tutorials.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Words and buttons online</title>
 	<meta name="description" content="A collection of interactive pages about maths and programming" />
 	<meta http-equiv="Cache-Control" content="no-cache" />

--- a/pages/apl_deserves_its_renaissance_too.html
+++ b/pages/apl_deserves_its_renaissance_too.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>APL deserves its renaissance too</title>
 	<meta name="description" content="APL tutorial explaining the meaning of life←{↑1 ⍵∨.∧3 4=+/,¯1 0 1∘.⊖¯1 0 1∘.⌽⊂⍵}">
 	<meta name="keywords" content="programming, tutorials">

--- a/pages/arctangent_scale_its_like_the_logarithmic_scale_but_infinite.html
+++ b/pages/arctangent_scale_its_like_the_logarithmic_scale_but_infinite.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Arctangent scale. It's like the logarithmic scale but infinite</title>
 	<meta name="description" content="An interactive demo of how, with arctangent used as a scale, we can show any function on a screen. And not just a fragment of it but the whole function.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/binary_search.html
+++ b/pages/binary_search.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Binary search</title>
 	<meta name="description" content="An interactive demo of the binary search algorithm along with its one slightly more obscure but promising variant.">
 	<meta name="keywords" content="algorithms, tutorials">

--- a/pages/biwhatever_transformations.html
+++ b/pages/biwhatever_transformations.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Bi-whatever transformations</title>
 	<meta name="description" content="An interactive explanation of how polynomial transformations such as trilinear or biquadratic or even linear-cubic work, and how to craft your own.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/can_we_use_lemniscates_for_ultra_cheap_vector_gaphics.html
+++ b/pages/can_we_use_lemniscates_for_ultra_cheap_vector_gaphics.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Can we use lemniscates for ultra-cheap vector graphics?</title>
 	<meta name="description" content="This depicts an old idea of using multifocal lemniscates to draw arbitrary shapes. In some applications, this may be indeed an economical alternative to splines.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/can_you_tell_an_assembly_language_when_you_see_one.html
+++ b/pages/can_you_tell_an_assembly_language_when_you_see_one.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Can you tell an assembly language when you see one?</title>
 	<meta name="description" content="An interactive quiz featuring several obscure high-level languages and assembly variants.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/challenge_your_performance_intuition_with_cpp_magic_squares.html
+++ b/pages/challenge_your_performance_intuition_with_cpp_magic_squares.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Challenge your performance intuition with C++ magic squares</title>
 	<meta name="description" content="An interactive quiz where you get to estimate the performance difference between several variants of the same code.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/challenge_your_performance_intuition_with_cpp_operators.html
+++ b/pages/challenge_your_performance_intuition_with_cpp_operators.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Challenge your performance intuition with C++ operators</title>
 	<meta name="description" content="Another interactive quiz where you get to estimate the performance difference between several variants of the same code.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/challenge_your_performance_intuition_with_cpp_sine.html
+++ b/pages/challenge_your_performance_intuition_with_cpp_sine.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Challenge your performance intuition with C++ sine</title>
 	<meta name="description" content="One more interactive quiz. This time, it's all about the sine function. Which one is faster and when?">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/challenge_your_performance_intuition_with_nanosecond_sorting.html
+++ b/pages/challenge_your_performance_intuition_with_nanosecond_sorting.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Challenge your performance intuition with nanosecond sorting</title>
 	<meta name="description" content="And yet another interactive quiz where you get to estimate the performance difference between several variants of the same code.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/cheap_trick_to_speed_up_recursion_in_cpp.html
+++ b/pages/cheap_trick_to_speed_up_recursion_in_cpp.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>A cheap trick to speed up recursion in C++</title>
 	<meta name="description" content="More often than not, recursion is not your performance problem, to begin with. But even if it is, you can often avoid recursion altogether. When for some reason you can't, this trick helps.">
 	<meta name="keywords" content="programming, demos">

--- a/pages/check_if_your_performance_intuition_still_works_with_cuda.html
+++ b/pages/check_if_your_performance_intuition_still_works_with_cuda.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Check if your performance intuition still works with CUDA</title>
 	<meta name="description" content="An interactive quiz about microoptimizations in CUDA. 10 rounds, two pieces of code per each, you get to guess which is the faster.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/circles_and_lines_vs_polynomial_splines.html
+++ b/pages/circles_and_lines_vs_polynomial_splines.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Circles and lines vs. polynomial splines</title>
 	<meta name="description" content="An alternative to polynomial splines. Smooth parametric curves made from arcs and line segments.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/complex_numbers_and_conformal_mapping.html
+++ b/pages/complex_numbers_and_conformal_mapping.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Complex numbers and conformal mapping</title>
 	<meta name="description" content="This explains the geometry of complex numbers. Explains conformal transformations, introduces analytic functions, and shows that analytic complex functions are conformal. And using the connection between the geometry and the analysis explains it all in just some five minutes.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/cpp_magic_squares_demystified_with_valgrind_and_disassembly.html
+++ b/pages/cpp_magic_squares_demystified_with_valgrind_and_disassembly.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>C++ magic squares demystified with Valgrind and disassembly</title>
 	<meta name="description" content="A comment on the 'Magic Squares Quiz'.">
 	<meta name="keywords" content="">

--- a/pages/either_your_estimates_suck_or_your_job_does.html
+++ b/pages/either_your_estimates_suck_or_your_job_does.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Either your estimates suck or your job does</title>
 	<meta name="description" content="This page uses polynomial modeling to show why software engineering tasks are often impossible to estimate.">
 	<meta name="keywords" content="mathematics, programming">

--- a/pages/error_codes_are_not_numbers_but_they_are_can_we_exploit_that.html
+++ b/pages/error_codes_are_not_numbers_but_they_are_can_we_exploit_that.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Error codes are not numbers. But they are. Can we exploit that?</title>
 	<meta name="description" content="An interactive explanation of how we can use floating-point NaNs as error code holders in C++.">
 	<meta name="keywords" content="programming, mathematics, demos">

--- a/pages/estimating_floating_point_error_the_easy_way.html
+++ b/pages/estimating_floating_point_error_the_easy_way.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Estimating floating-point error the easy way</title>
 	<meta name="description" content="An explanation of how to measure computational error while working with floating-point numbers, and why.">
 	<meta name="keywords" content="programming, mathematics, demos">

--- a/pages/fortran_is_still_a_thing.html
+++ b/pages/fortran_is_still_a_thing.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Fortran is still a thing</title>
 	<meta name="description" content="A short essay about Fortran in the modern world.">
 	<meta name="keywords" content="programming">

--- a/pages/gauss_seidel_visually_explained.html
+++ b/pages/gauss_seidel_visually_explained.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Gauss–Seidel visually explained</title>
 	<meta name="description" content="An interactive demo of the Gauss-Seidel method for solving linear equation systems. When and why does it work? And why, when you flip the equations, it suddenly stop working? You can now play and see.">
 	<meta name="keywords" content="mathematics, algorithms, tutorials">
@@ -402,7 +403,7 @@ function draw_solver_1(client_x, client_y, do_guides){
 		prev_y = cur_y;
 		if(i % 2 == 0){
 			cur_x = (solver_1_eq_1[2] - solver_1_eq_1[1]*prev_y) / solver_1_eq_1[0];
-			
+
 		}else{
 			cur_y = (solver_1_eq_2[2] - solver_1_eq_2[0]*prev_x) / solver_1_eq_2[1];
 		}
@@ -494,12 +495,12 @@ function draw_solver_1(client_x, client_y, do_guides){
 	const a_1 = solver_1_eq_1[0] / n_1;
 	const b_1 = solver_1_eq_1[1] / n_1;
 	const c_1 = solver_1_eq_1[2] / n_1;
-	
+
 	const n_2 = Math.pow(solver_1_eq_2[0]*solver_1_eq_2[0] + solver_1_eq_2[1]*solver_1_eq_2[1], 0.5);
 	const a_2 = solver_1_eq_2[0] / n_2;
 	const b_2 = solver_1_eq_2[1] / n_2;
 	const c_2 = solver_1_eq_2[2] / n_2;
-	
+
 	function sign(x) {
 		if (x < 0) return "-";
 		return "+";
@@ -507,7 +508,7 @@ function draw_solver_1(client_x, client_y, do_guides){
 	function unsigned(x) {
 		return Math.abs(x).toFixed(2);
 	}
-	
+
 	// iteration count
 	results = document.getElementById("results");
 	results.innerHTML = "<span style='color:#d64562'>Red line: "+a_1.toFixed(2) + "x " + sign(b_1) + " " + unsigned(b_1) + "y " + sign(c_1) + " " + unsigned(c_1) + " = 0 </span><br>";
@@ -545,7 +546,7 @@ function radio(n) {
 function swap_lines() {
 	a = solver_1_eq_1[0];
 	b = solver_1_eq_1[1];
-	c = solver_1_eq_1[2]; 
+	c = solver_1_eq_1[2];
 	solver_1_eq_1[0] = solver_1_eq_2[0];
 	solver_1_eq_1[1] = solver_1_eq_2[1];
 	solver_1_eq_1[2] = solver_1_eq_2[2];
@@ -599,7 +600,7 @@ Here's the interactive visualisation. The red and blue lines are two equations, 
 	<script language="JavaScript">
 	init_solver_1();
 	</script>
-	
+
 	<p>
 The key to understanding the Gauss-Seidel method is in its geometry. When we compute an <i>x<sub>i</sub></i> coordinate from the <i>i</i>-th equation, this is exactly like putting an arrow from the current solution to the line representing the <i>i</i>-th equation along the coordinate's axis.
 	</p>

--- a/pages/honeycomb_texture_generator.html
+++ b/pages/honeycomb_texture_generator.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Honeycomb texture generator</title>
 	<meta name="description" content="This generates honeycomb textures of a special quasi-irrational form. Explanation included.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/how_much_math_can_you_do_in_10_lines_of_python.html
+++ b/pages/how_much_math_can_you_do_in_10_lines_of_python.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>How much math can you do in 10 lines of Python</title>
 	<meta name="description" content="An interactive introduction into concise Python / basic linear algebra.">
 	<meta name="keywords" content="programming, mathematics">

--- a/pages/if_i_were_to_invent_a_programming_language_for_the_21st_century.html
+++ b/pages/if_i_were_to_invent_a_programming_language_for_the_21st_century.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>If I were to invent a programming language for the 21st century</title>
 	<meta name="description" content="A short essay about the evolution of programming languages.">
 	<meta name="keywords" content="programming">

--- a/pages/image_darning.html
+++ b/pages/image_darning.html
@@ -1,7 +1,8 @@
-﻿<html lang="en">
+<html lang="en">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Image darning</title>
 	<meta name="description" content="A simple image processing algorithm that cleans up dirt stains from old newspapers. I called it “darning” because of how it works.">
 	<meta name="keywords" content="mathematics, algorithms, demos">

--- a/pages/index.html
+++ b/pages/index.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Words and buttons online</title>
 	<meta name="description" content="A collection of interactive pages about maths and programming" />
 	<meta http-equiv="Cache-Control" content="no-cache" />
@@ -100,7 +101,7 @@ li {
 	<center>
 	<h1>Hello, world!</h1>
 	<p style="width: 600pt;">This is <i>Words and Buttons Online</i> — a collection of&nbsp;interactive <a href="all_tutorials.html">#tutorials</a>, <a href="all_demos.html">#demos<a/>, and <a href="all_quizzes.html">#quizzes</a> about <a href="all_mathematics.html">#mathematics</a>, <a href="all_algorithms.html">#algorithms</a>, and <a href="all_programming.html">#programming</a>.</p>
-	
+
 	<div style="height: 24pt;"></div>
 
 <span id="timeline"><h1>All the pages</h1></span><p class="title" title="2025-09-21 (#63)"><a href="gauss_seidel_visually_explained.html">Gauss–Seidel visually explained</a></p>

--- a/pages/interactive_explanation_of_marching_cubes_and_dual_contouring.html
+++ b/pages/interactive_explanation_of_marching_cubes_and_dual_contouring.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Interactive explanation of marching cubes and dual contouring</title>
 	<meta name="description" content="Marching cubes and dual contouring are often used for mesh generation. This explanation shows how they work, what are their differences, similarities, and limitations.">
 	<meta name="keywords" content="mathematics, algorithms, tutorials">

--- a/pages/interactive_guide_to_homogeneous_coordinates.html
+++ b/pages/interactive_guide_to_homogeneous_coordinates.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Interactive guide to homogeneous coordinates</title>
 	<meta name="description" content="This interactive guide shows how homogeneous coordinates actually make programming geometry simpler and not more complicated. The page explains the extra coordinate, matrices, and generalized transformations. Most of what you need to know about projective geometry as a practicing programmer is here.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/interactive_introduction_to_iterative_algorithms.html
+++ b/pages/interactive_introduction_to_iterative_algorithms.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>An interactive introduction to iterative algorithms</title>
 	<meta name="description" content="An interactive explanation of how iterative algorithms work. This explains convergence and the exit condition problem on an oversimplified linear system solver.">
 	<meta name="keywords" content="mathematics, algorithms, demos">

--- a/pages/interactive_mnemonics_for_dot_and_cross_vector_products.html
+++ b/pages/interactive_mnemonics_for_dot_and_cross_vector_products.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Interactive mnemonics for dot and cross vector products</title>
 	<meta name="description" content="Just a pair of mnemonics for dot and cross vector products. They present the functions, show how they work, and why one is dot and the other is cross.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/lagrange_polynomial_as_a_gateway_drug_to_basis_splines.html
+++ b/pages/lagrange_polynomial_as_a_gateway_drug_to_basis_splines.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Lagrange polynomial as a gateway drug to basis splines</title>
 	<meta name="description" content="This explains Lagrange interpolation: what is the Lagrange polynomial, why does it run through all the points, what is the basis polynomial, and how come it's a polynomial in the first place.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/learn_you_a_lisp_in_0_minutes.html
+++ b/pages/learn_you_a_lisp_in_0_minutes.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Learn you a Lisp in 0 minutes</title>
 	<meta name="description" content="A short quiz to reveal your hidden knowledge of Lisp.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/lexical_differential_highlighting_instead_of_syntax_highlighting.html
+++ b/pages/lexical_differential_highlighting_instead_of_syntax_highlighting.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Lexical differential highlighting instead of syntax highlighting</title>
 	<meta name="description" content="This type of highlighting is ideal for assembly. With it, the things that shouldn't seem similar usually don't.">
 	<meta name="keywords" content="programming, demos">

--- a/pages/logic_programming_in_cpp.html
+++ b/pages/logic_programming_in_cpp.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Logic programming in C++</title>
 	<meta name="description" content="This shows that there is an invisible Prolog in every C++ compiler. It's up to you what to do with it but it's there.">
 	<meta name="keywords" content="programming, tutorials">

--- a/pages/mathematical_analysis_explained_with_python_blood_and_tnt.html
+++ b/pages/mathematical_analysis_explained_with_python_blood_and_tnt.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Mathematical analysis explained with Python, blood, and TNT</title>
 	<meta name="description" content="A brief introduction to mathematical analysis with a little SymPy on the side. The page explains how to disassemble a function, and how to assemble it back from the derivatives.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/nurbs_is_just_an_acronym.html
+++ b/pages/nurbs_is_just_an_acronym.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>NURBS is just an acronym</title>
 	<meta name="description" content="NURBS stands for the non-uniform rational basis spline. There are three separate concepts. This guide walks you through these concepts one by one.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/outperforming_everything_with_anything.html
+++ b/pages/outperforming_everything_with_anything.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Outperforming everything with anything</title>
 	<meta name="description" content="A 100 lines of Python code that substitute the compiler front-end for a specific computation. This shows that you don't need a “fast” compiling language to write efficient code. In fact, a compilation is only one of the multiple ways to achieve speed.">
 	<meta name="keywords" content="programming, demos">

--- a/pages/outperforming_lapack_with_c_metaprogramming.html
+++ b/pages/outperforming_lapack_with_c_metaprogramming.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Outperforming LAPACK with C metaprogramming</title>
 	<meta name="description" content="Ok, it's not really about LAPACK. You can consider it clickbait if you wish. It's about how to tell a compiler to write the code you want with a limited arsenal of tools the C language provides.">
 	<meta name="keywords" content="programming, demos">

--- a/pages/partial_order_and_non_boolean_logic.html
+++ b/pages/partial_order_and_non_boolean_logic.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Partial order and non-Boolean logic</title>
 	<meta name="description" content="Non-Boolean logics are rare but not extinct. Interval logic is one example. Sometimes, you can implement a logic you want within total order or partial order but sometimes even that isn't enough and you need an even more general relation. With operator overloading, you have the freedom to go there but you also have less assurance when working within the total order.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/playing_a_game_of_chance_with_cpp_inline_keyword.html
+++ b/pages/playing_a_game_of_chance_with_cpp_inline_keyword.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Playing a game of chance with C++ inline keyword</title>
 	<meta name="description" content="It's about one particular aspect of C++ compilation that makes programming with the “inline” into a game of chance.">
 	<meta name="keywords" content="programming">

--- a/pages/polynomial_approximation_and_interpolation.html
+++ b/pages/polynomial_approximation_and_interpolation.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Polynomial approximation and interpolation</title>
 	<meta name="description" content="This explains approximation and interpolation, how to use polynomials for that, and how to make both concepts work together.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/programmers_guide_to_polynomials_and_splines.html
+++ b/pages/programmers_guide_to_polynomials_and_splines.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Programmer's guide to polynomials and splines</title>
 	<meta name="description" content="This is a brief introduction into polynomials. From how to make a polynomial run through your set of points to how to make it into a spline.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/programmers_introduction_to_linear_equations.html
+++ b/pages/programmers_introduction_to_linear_equations.html
@@ -2,6 +2,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Programmer's guide to linear equations</title>
 	<meta name="description" content="This is an introduction to linear equation systems. It explains linear dependency, under- and over-specification, direct and iterative solvers. The guide should give you enough knowledge to find a proper solution for your task but not enough to implement one efficiently yourself.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/quadratic_splines_are_useful_too.html
+++ b/pages/quadratic_splines_are_useful_too.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Quadratic splines are useful too</title>
 	<meta name="description" content="This explains simple quadratic splines, how to craft one yourself, and why.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/rational_interpolation.html
+++ b/pages/rational_interpolation.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Rational interpolation</title>
 	<meta name="description" content="Rational interpolation is a step forward from polynomial interpolation towards rational splines. With rational interpolation, you can build functions that run through a set of points and also have vertical asymptotes whenever you want. With this capability, you can now model functions like logarithms better.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/redundant_stories_about_redundancy.html
+++ b/pages/redundant_stories_about_redundancy.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Redundant stories about redundancy</title>
 	<meta name="description" content="Component redundancy is used heavily in safety-critical and mission-critical systems for reliability improvement. But outside this niche, it's surprisingly little known in the world of software. Which is a shame since it's a simple but economical idea. It costs nothing to keep in mind, and it saves you a lot on hotfixes and emergency repairs.">
 	<meta name="keywords" content="programming">

--- a/pages/simple_image_vectorization.html
+++ b/pages/simple_image_vectorization.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Simple image vectorization</title>
 	<meta name="description" content="This is an example of an image vectorization algorithm. It shows the bilinear interpolation, polynomial approximation, differential analysis, and iterative algorithms working together to solve a practical problem">
 	<meta name="keywords" content="mathematics, algorithms, demos">

--- a/pages/sine_and_cosine.html
+++ b/pages/sine_and_cosine.html
@@ -3,6 +3,7 @@
   <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Sine and cosine</title>
 	<meta name="description" content="A pair of interactive mnemonics for sine and cosine. There are also examples of practical usage. Basically, the second half of a tutorial is about how the first half was made.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/so_you_think_you_know_c.html
+++ b/pages/so_you_think_you_know_c.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>So you think you know C?</title>
 	<meta name="description" content="It's a C test. If you think you know C, take this test. It only has 5 questions.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/static_typing_isnt_free.html
+++ b/pages/static_typing_isnt_free.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Static typing isn’t free. Where do you think the C++ angry mob comes from?</title>
 	<meta name="description" content="Type inference works like logic deduction so any program in a statically typed language is two programs. The first one is the thing you sell, and the second – is a model that undergoes some sort of verification every time you run a compiler. This second program, although, often being written unknowingly, is not a free bonus, it’s something you have to pay for in several ways.">
 	<meta name="keywords" content="programming, tutorials">

--- a/pages/swine_simplicial_weight_interpolation_and_extrapolation.html
+++ b/pages/swine_simplicial_weight_interpolation_and_extrapolation.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>SWInE: Simplicial Weight Interpolation and Extrapolation</title>
 	<meta name="description" content="An alternative to splines nobody knows about. The localization of Shepard's method for a simplicial complex.">
 	<meta name="keywords" content="mathematics, demos">

--- a/pages/sympy_makes_math_fun_again.html
+++ b/pages/sympy_makes_math_fun_again.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=0.84">
+	<meta name="color-scheme" content="light dark">
 	<title>SymPy makes math fun again</title>
 	<meta name="description" content="An introduction into symbolic computations in Python. Don't worry, it's much simpler than it sounds. It's about making Python do your math for you with very little investment in the technology.">
 	<meta name="keywords" content="programming, mathematics, tutorials">

--- a/pages/the_real_cpp_killers.html
+++ b/pages/the_real_cpp_killers.html
@@ -3,12 +3,13 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>The Real C++ Killers (Not You, Rust)</title>
 	<meta name="description" content="All the “C++ killers”, even these which I wholeheartedly love and respect like Rust, Julia, and D, help you write more features with fewer bugs, but they don't much help when you need to squeeze the very last FLOPS from the hardware you rent. As such, they don’t have a competitive advantage over C++. Or, for that matter, even over each other. Most of them, for instance, Rust, Julia, and Clang even share the same backend. You can’t win a car race if you all share the same car. So, which technologies do hold a competitive advantage over C++ or, speaking generally, all the traditional ahead-of-time compilers?">
 	<meta name="keywords" content="programming">
 	<link rel="shortcut icon" type="image/x-icon" href="favicon.svg" />
 	<style>
-	 
+
 body {
 	margin: 2em;
 }
@@ -161,7 +162,7 @@ And suddenly it turns out that all the “C++ killers”, even those which I who
 As such, they just have a competitive advantage over C++. Or, for that matter, even over each other. Most of them, for instance, Rust, Julia, and Cland even share the same backend. No one wins a car race if all the racers sit in the same car.
 	</p>
 	<p>
-So, which technologies do give you a competitive advantage over C++ or, speaking generally, all the traditional ahead-of-time compilers? 
+So, which technologies do give you a competitive advantage over C++ or, speaking generally, all the traditional ahead-of-time compilers?
 	</p>
 	<p>
 Good question!
@@ -169,7 +170,7 @@ Good question!
 	<p>
 Glad you asked.
 	</p>
-	
+
 	<h2>
 C++ killer number 1. SPIRAL
 	</h2>
@@ -182,7 +183,7 @@ But before we go with SPIRAL itself, let’s check how well your intuition works
 	<pre>
 <span style="color: #d64562;">// version 1</span>
 auto y = std::sin(x);
- 
+
 <span style="color: #457fd6;">// version 2</span>
 y = -0.000182690409228785*x*x*x*x*x*x*x
     +0.00830460224186793*x*x*x*x*x
@@ -209,20 +210,20 @@ Next question. What works faster, using logical operations with short-circuiting
 	<table><tr>
 	<td>
 	<pre>
-<span style="color: #d64562;">// version 1</span>	
-  if (xs[i] == 1 
-   && xs[i+1] == 1 
-   && xs[i+2] == 1 
+<span style="color: #d64562;">// version 1</span>
+  if (xs[i] == 1
+   && xs[i+1] == 1
+   && xs[i+2] == 1
    && xs[i+3] == 1) // xs are bools stored as ints
- 
+
 <span style="color: #457fd6;">// version 2</span>
   inline int sq(int x) {
       return x*x;
   }
- 
-  if(sq(xs[i] - 1) 
-   + sq(xs[i+1] - 1) 
-   + sq(xs[i+2] - 1) 
+
+  if(sq(xs[i] - 1)
+   + sq(xs[i+1] - 1)
+   + sq(xs[i+2] - 1)
    + sq(xs[i+3] - 1) == 0)
 </pre>
 	</td>
@@ -252,7 +253,7 @@ And one more. What sorts triplets faster: a swap-sort with branching or a branch
         swap(s[1], s[2]);
     if(s[0] > s[1])
         swap(s[0], s[1]);
- 
+
 <span style="color: #457fd6;">// version 2</span>
     const auto a = s[0];
     const auto b = s[1];
@@ -364,7 +365,7 @@ def matmul(A, B, C):
         C[i, j] = tmp
 </pre>
 	</td>
-	</tr></table>	
+	</tr></table>
 
 	<p>
 Numba is one of the Python compilers that makes C++ obsolete. In theory, however, it’s not any better than C++ since it uses the same backends. It uses CUDA for GPU programming and LLVM for CPU. In practice, since it doesn’t require an ahead-of-time rebuild for every new architecture, Numba solutions adapt better to every new hardware and its available optimizations.
@@ -393,7 +394,7 @@ Let’s play another game. I’ll give you three pieces of code, and you’ll gu
         mov   hwnd,eax
     invoke ShowWindow, hwnd,CmdShow     <span style="color: #777;">; display our window on desktop</span>
     invoke UpdateWindow, hwnd           <span style="color: #777;">; refresh the client area</span>
- 
+
     .while TRUE                         <span style="color: #777;">; Enter message loop</span>
         invoke GetMessage, ADDR msg,NULL,0,0
         .break .if (!eax)
@@ -498,7 +499,7 @@ You just saw three assembly samples yourself. None of them looks like a “tradi
 	<p>
 So, ForwardCom is the assembly in which you can write optimal code that will never go obsolete, and which doesn’t make you learn a “traditional” assembly. For all practical considerations, it is the C of the future. Not C++.
 	</p>
-	
+
 	<h2>
 So when will С++ finally die?
 	</h2>

--- a/pages/the_simplest_possible_smooth_contouring_algorithm.html
+++ b/pages/the_simplest_possible_smooth_contouring_algorithm.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>The simplest possible smooth contouring algorithm</title>
 	<meta name="description" content="A 3-part smooth contouring algorithm that shows partial derivatives, gradients, and parametric polynomials working together.">
 	<meta name="keywords" content="mathematics, algorithms, demos">

--- a/pages/tries_as_the_evolution_of_nothing.html
+++ b/pages/tries_as_the_evolution_of_nothing.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Tries as the evolution of nothing</title>
 	<meta name="description" content="Trie is a data structure. Like “tree” but different. This tutorial explains the concept behind the trie, what makes it efficient, and when.">
 	<meta name="keywords" content="algorithms, programming, tutorials">

--- a/pages/trippy_polynomials_in_arctangent_scale.html
+++ b/pages/trippy_polynomials_in_arctangent_scale.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=0.84">
+	<meta name="color-scheme" content="light dark">
 	<title>Trippy polynomials in arctangent scale</title>
 	<meta name="description" content="This shows the global properties of polynomials, their derivatives, and explains how the Maclaurine and Taylor series work all with animated plots in arctangent scale.">
 	<meta name="keywords" content="mathematics, tutorials">

--- a/pages/using_logical_operators_for_logical_operations_is_good.html
+++ b/pages/using_logical_operators_for_logical_operations_is_good.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Using logical operators for logical operations is good</title>
 	<meta name="description" content="This is the follow-up for the “Challenge your intuition with C++ operators”. It shows that despite the occasional gains from a better compilation, using the proper operators is still beneficial in the long run.">
 	<meta name="keywords" content="programming, quizzes">

--- a/pages/vastly_outperforming_lapack_with_cpp_metaprogramming.html
+++ b/pages/vastly_outperforming_lapack_with_cpp_metaprogramming.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Vastly outperforming LAPACK with C++ metaprogramming</title>
 	<meta name="description" content="Still not really about LAPACK. It's a second part of the “outperforming” series explaining how the C++ metaprogramming can appear useful for efficient code generation.">
 	<meta name="keywords" content="programming, demos">

--- a/pages/why.html
+++ b/pages/why.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Why did I write Geometry for Programmers</title>
 	<meta name="description" content="Why did I write Geometry for Programmers">
 	<meta name="keywords" content="">

--- a/pages/why_erlang_is_among_the_few_true_computer_languages.html
+++ b/pages/why_erlang_is_among_the_few_true_computer_languages.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Why Erlang is among the few true computer languages</title>
 	<meta name="description" content="Usually, a language is something that is used for bilateral communication. For programming languages, this is often untrue. Erlang shows how this can be achieved still.">
 	<meta name="keywords" content="programming">

--- a/pages/why_is_it_ok_to_divide_by_0_0.html
+++ b/pages/why_is_it_ok_to_divide_by_0_0.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Why is it ok to divide by 0.0?</title>
 	<meta name="description" content="This explains why dividing by zero in floating-point numbers is ok.">
 	<meta name="keywords" content="programming, mathematics">

--- a/pages/why_learn_about_the_golden_section_search.html
+++ b/pages/why_learn_about_the_golden_section_search.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Why learn about the golden-section search</title>
 	<meta name="description" content="An interactive demo of bisection search and golden ratio search algorithms. There is also a motivation to learn them both. Spoiler alert! One converges better, and the other has a better computational cost.">
 	<meta name="keywords" content="mathematics, algorithms, tutorials">
@@ -235,7 +236,7 @@ function draw_gs(){
 	context.stroke();
 	context.fill();
 	context.closePath();
-	
+
 	const xb = x_to_client(b_gs) + 0.5;
 	const yb = y_to_client(f(b_gs)) + 0.5;
 	context.beginPath();
@@ -258,7 +259,7 @@ function draw_gs(){
 	const tau = 0.618;
 	const x1 = b_gs - (b_gs-a_gs)*tau;
 	const x2 = a_gs + (b_gs-a_gs)*tau;
-	
+
 	const xc1 = x_to_client(x1) + 0.5;
 	const yc1 = y_to_client(f(x1)) + 0.5;
 	context.fillStyle="#d64562";
@@ -274,7 +275,7 @@ function draw_gs(){
 	context.stroke();
 	context.closePath();
 	context.setLineDash([]);
-	
+
 	const xc2 = x_to_client(x2) + 0.5;
 	const yc2 = y_to_client(f(x2)) + 0.5;
 	context.fillStyle="#d64562";
@@ -305,7 +306,7 @@ function reset_to_1_iteration_gs() {
 function do_one_iteration_gs() {
 	const f_text = document.getElementById("f_gs").value;
 	eval('function f(x, y) { return ' + f_text + ';}');
-	
+
 	const tau = 0.618;
 	const x1 = b_gs - (b_gs-a_gs)*tau;
 	const x2 = a_gs + (b_gs-a_gs)*tau;
@@ -374,7 +375,7 @@ function draw(){
 	context.stroke();
 	context.fill();
 	context.closePath();
-	
+
 	const xb = x_to_client(b) + 0.5;
 	const yb = y_to_client(f(b)) + 0.5;
 	context.beginPath();
@@ -485,7 +486,7 @@ You can play with the algorithm using the form below.
 <i>b<sub>0</sub></i>:<input type="text" id="b" oninput="reset_to_1_iteration();" value="8.25" style="width:36pt" />
 <i>&sigma;<sub>x</sub></i>:<input type="text" id="sigma" oninput="reset_to_1_iteration();" value="0.0001" style="width:48pt" />
 	<br>
-	current iteration: 
+	current iteration:
 	<span id="i">0</span>
 	<br>
 	<button type="button" id="reset" onclick="reset_to_1_iteration();">Reset to the 1st iteration</button>
@@ -515,7 +516,7 @@ Now, if <nobr><i>a<sub>1</sub> &lt; b<sub>1</sub></i></nobr> then the minimum is
 There are some marginal cases like what if the function in <i>a<sub>1</sub></i> and <i>b<sub>1</sub></i> is exactly the same, or what if the function in <i>a</i> or <i>b</i> is less than in <i>a<sub>1</sub></i> or <i>b<sub>1</sub></i>. These cases are interesting but not important for the core idea of the algorithm.
 	</p>
 	<p>
-So let's say on each iteration, we narrow our interval to <nobr><i>[a<sub>1</sub>, b]</i></nobr> or <nobr><i>[a, b<sub>1</sub>]</i></nobr>. The proportion <nobr><i>(b-a<sub>1</sub>) / (b-a)</i></nobr> is exactly the same as <nobr><i>(b - a<sub>1</sub>) / (b - a)</i></nobr>, it's a constant number and it's roughly 0.62 by design. Which is more than 0.5. This means that the algorithm narrows down the interval pretty much like the bisection algorithm does but... slower. That's the only difference. 
+So let's say on each iteration, we narrow our interval to <nobr><i>[a<sub>1</sub>, b]</i></nobr> or <nobr><i>[a, b<sub>1</sub>]</i></nobr>. The proportion <nobr><i>(b-a<sub>1</sub>) / (b-a)</i></nobr> is exactly the same as <nobr><i>(b - a<sub>1</sub>) / (b - a)</i></nobr>, it's a constant number and it's roughly 0.62 by design. Which is more than 0.5. This means that the algorithm narrows down the interval pretty much like the bisection algorithm does but... slower. That's the only difference.
 	</p>
 	<p>
 Both bisection search and golden-section search are said to have linear convergence. This means that they both reduce interval linearly, the proportion between the interval length on <nobr><i>(i+1)</i>-th</nobr> iteration and on <nobr><i>i</i>-th</nobr> is always the same. But bisection has a better rate and therefore converges faster.
@@ -530,19 +531,19 @@ There is a trick. And the trick is almost magical. As in performance art magical
 In every iteration after that, one of the points you already have the target function computed for remains stationary regardless of the current iteration's result. This means, that you only have to compute your target function once per iteration, not twice. And this makes the golden-section search more computationally efficient in practice even if, mathematically speaking, it has an undeniably worse convergence ratio.
 	</p>
 	<p>
-But how come we get to keep one of the points? Glad you asked. That's exactly what we need the golden section for. 
+But how come we get to keep one of the points? Glad you asked. That's exactly what we need the golden section for.
 	</p>
 	<p>
 The golden ratio is by definition a number that connects the proportion of the part of an interval (<i>b</i>) to the whole interval (<i>a</i>) such as.
 	</p>
-	
+
 	<table class="formula">
 	<tr>
 	<td style="border-bottom: 1px solid black">
-a + b 
+a + b
 	</td>
 	<td rowspan=2>
- = 
+ =
 	</td>
 	<td style="border-bottom: 1px solid black">
 a
@@ -564,7 +565,7 @@ b
 There is one and only one such number and it's approximately: 1.618033.
 	</p>
 	<p>
-Well, you were probably expecting to see 0.62 from before. No problem: 
+Well, you were probably expecting to see 0.62 from before. No problem:
 	</p>
 <table class="formula">
 	<tr>
@@ -584,20 +585,20 @@ Well, you were probably expecting to see 0.62 from before. No problem:
 	<p>
 Here you go.
 	</p>
-	
+
 	<form>
 <i>F(x)</i>:
 	<input type="text" id="f_gs" oninput="reset_to_1_iteration_gs();" value="(x-5)**2/5" style="width:150pt" />
 <i>a<sub>0</sub></i>:<input type="text" id="a_gs" oninput="reset_to_1_iteration_gs();" value="-0.5" style="width:36pt" />
 <i>b<sub>0</sub></i>:<input type="text" id="b_gs" oninput="reset_to_1_iteration_gs();" value="8.25" style="width:36pt" />
 	<br>
-	current iteration: 
+	current iteration:
 	<span id="i_gs">0</span>
 	<br>
 	<button type="button" id="reset_gs" onclick="reset_to_1_iteration_gs();">Reset to the 1st iteration</button>
 	<button type="button" id="iplus_gs" onclick="do_one_iteration_gs();">Do 1 iteration</button>
 	</form>
-	
+
 	<canvas id="plot_gs" width=640 height=512></canvas>
 	<br>
 	<span id="log_gs" class="formula"></span>

--- a/pages/yet_another_alternative_to_floating_point_numbers.html
+++ b/pages/yet_another_alternative_to_floating_point_numbers.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Yet another alternative to floating-point numbers</title>
 	<meta name="description" content="This shows how computable intervals written in rational bounds may not only account for the input error but keep computational error under control as well.">
 	<meta name="keywords" content="mathematics, programming, quizzes">

--- a/pages/yet_another_floating_point_tutorial.html
+++ b/pages/yet_another_floating_point_tutorial.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Yet another floating-point tutorial</title>
 	<meta name="description" content="Most of what you should know about floating-point numbers put together in an interactive tutorial with quests and puzzles.">
 	<meta name="keywords" content="mathematics, programming, tutorials">

--- a/pages/you_dont_have_to_learn_assembly_to_read_disassembly.html
+++ b/pages/you_dont_have_to_learn_assembly_to_read_disassembly.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width">
+	<meta name="color-scheme" content="light dark">
 	<title>Even if you can't write assembly like a poet, you can read disassembly like a hunter</title>
 	<meta name="description" content="This is a very concise introduction to x86 disassembly. It shows that you probably have all the skills to start reading disassembly right now even if you thought it was too complicated for you. It really isn't, see it for yourself.">
 	<meta name="keywords" content="programming, tutorials">


### PR DESCRIPTION
I decided to add the `meta` element in-between `viewport` and `title`, because layout should be prioritized over color (reflows are expensive), and full-page color is prioritized over "small" (typically) text. `color-scheme` must be declared near the beginning of files, to reduce the likelihood of the "flash-bang effect" when the browser starts rendering a page.

Link-contrast is kinda bad in dark-mode (which is to be expected). Should I add [a media-query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) to fix it for this PR or a separate one? I don't even know which shade of blue you'd prefer for dark-theme. Personally, I'd choose this green (or similar): `#00ee00`.

BTW, [SuperHTML](https://github.com/kristoff-it/superhtml) detected **many** "errors" in almost all files, including unclosed tags, before I even edited anything.

Oh, and the minor formatting change happened because my `.editorconfig` has `trim_trailing_whitespace = true`

> [!note]
> I didn't manually copy-paste the element. I actually used a Helix macro to auto-insert the element at the same line-number. The only "manual work" was pressing buttons and reviewing each file